### PR TITLE
Use global state + misc

### DIFF
--- a/components/pages/farms/index.tsx
+++ b/components/pages/farms/index.tsx
@@ -5,6 +5,7 @@ import { ethers } from "ethers"
 import { useEffect, useState } from 'react'
 import InitialPool from '../../../types/InitialPool'
 import Farm from '../../../types/Farm'
+import Pool from '../../../types/Pool'
 
 interface FarmsProps {
     initialFarms: Farm[]
@@ -25,7 +26,7 @@ const Farms: React.FC<FarmsProps> = ({ initialFarms, tokenPrices }) => {
             {
                 farms.map((item, index) => (
                     <div key={index}>
-                        <Stake basicInfo={item.basicInfo} initialPool={item.pool as InitialPool} prices={prices} />
+                        <Stake basicInfo={item.basicInfo} pool={item.pool as Pool} prices={prices} />
                     </div>
                 ))
             }

--- a/components/popup/index.tsx
+++ b/components/popup/index.tsx
@@ -16,7 +16,7 @@ export function LoadingPopup({ loading, setLoading, showClosed = false }) {
         <div tw=" flex items-center background-color[rgba(0, 0, 0, 0.3)] height[100%] inset-0 z-30 width[100%]  justify-center fixed overflow-hidden">
             <div tw="relative ">
                 {showClosed && <div   >X</div>}
-                <img src={`/assets/images/loading.gif`}  alt="" onClick={() => setLoading(false)} />
+                <img tw="animate-spin h-8  w-8" src={`/assets/images/chad.png`}  alt="" onClick={() => setLoading(false)} />
             </div>
         </div>
     ) : <></>

--- a/context/FarmsContext.ts
+++ b/context/FarmsContext.ts
@@ -5,7 +5,8 @@ import FarmContextInterface from "../types/FarmContextInterface"
 const FarmsContext = createContext<FarmContextInterface>({
     lpFarms: null,
     singleStakeFarms: null,
-    prices: null
+    prices: null,
+    initialFetchDone: false
 })
 
 export default FarmsContext

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -40,7 +40,7 @@ function MyApp({ Component, pageProps }) {
         
         setPrices(priceArray)
         
-        const farmContextValue = createFarmContextValue(mappedLpFarms, mappedSingleFarms, priceArray)
+        const farmContextValue = createFarmContextValue(mappedLpFarms, mappedSingleFarms, priceArray, true)
         setFarmContext(farmContextValue)
         
         console.log("Farm context value", farmContextValue)
@@ -51,13 +51,15 @@ function MyApp({ Component, pageProps }) {
   function createFarmContextValue (
     lps: Farm[] = lpFarms, 
     singles: Farm[] = singleStakeFarms, 
-    pricesArray: Map<string, ethers.BigNumber> = prices
+    pricesArray: Map<string, ethers.BigNumber> = prices,
+    done: boolean = false
     ): FarmContextInterface {
     
-      const value: FarmContextInterface = {
+    const value: FarmContextInterface = {
       lpFarms: lps,
       singleStakeFarms: singles,
-      prices: pricesArray
+      prices: pricesArray,
+      initialFetchDone: done
     }
 
     return value

--- a/types/FarmContextInterface.ts
+++ b/types/FarmContextInterface.ts
@@ -5,6 +5,7 @@ interface FarmContextInterface {
     lpFarms: Farm[]
     singleStakeFarms: Farm[]
     prices: Map<string, ethers.BigNumber>
+    initialFetchDone: boolean
 }
 
 export default FarmContextInterface


### PR DESCRIPTION
The LP farms are now using the fetched pools from context. Needed few steps to make it work. Context will now have variable which is set to _true_ when pools and prices are fetched successfully. InitialPools also are now already Pools when passing them to separate Farm/Stake elements.

Also now shows the APR and TVL etc, without user being connected to the site. When user connects, pending rewards and users deposit amount is updated.

Added code for spinning Chad head loading popup (ripped from d3xm0rg :D). For LP farms the loading state is now removed if user denies the MM notification.

- need to still implement these things to the single staking components before merging